### PR TITLE
Add a acl::requirements class

### DIFF
--- a/manifests/requirements.pp
+++ b/manifests/requirements.pp
@@ -1,0 +1,5 @@
+class acl::requirements {
+  package{'acl':
+    ensure => 'present',
+  } -> Acl<| |>
+}


### PR DESCRIPTION
Ensure that the acl package is installed and that this is done
_before_ we try to manage any acls.

As on some initially stripped down systems the acl Package might not be available. You can simply include the `acl::requirements` class and the required package will be installed _before_ any acls are managed.
