### PR TITLE
X bit support

### DIFF
--- a/lib/puppet/provider/posix_acl/posixacl.rb
+++ b/lib/puppet/provider/posix_acl/posixacl.rb
@@ -86,8 +86,11 @@ Puppet::Type.type(:posix_acl).provide(:posixacl, parent: Puppet::Provider) do
       purge
     when :exact, :set
       cur_perm = permission
-      perm_to_set = @resource.value(:permission) - cur_perm
-      perm_to_unset = cur_perm - @resource.value(:permission)
+      # For comparison purposes, we want to change X to x as it's only useful
+      # for setfacl and isn't stored or noted by getfacl.
+      new_perm = @resource.value(:permission).map(&:downcase)
+      perm_to_set = new_perm - cur_perm
+      perm_to_unset = cur_perm - new_perm
       return false if perm_to_set.empty? && perm_to_unset.empty?
       # Take supplied perms literally, unset any existing perms which
       # are absent from ACLs given

--- a/lib/puppet/type/posix_acl.rb
+++ b/lib/puppet/type/posix_acl.rb
@@ -218,7 +218,7 @@ Puppet::Type.newtype(:posix_acl) do
         s = p.tr '-', ''
         r << (s.sub!('r', '') ? 'r' : '-')
         r << (s.sub!('w', '') ? 'w' : '-')
-        r << (s.sub!('x', '') ? 'x' : '-')
+        r << (s.sub!(/x/i, '') ? $~.to_s : '-')
         raise ArgumentError, %(Invalid permission set "#{p}".) unless s.empty?
       end
       r

--- a/lib/puppet/type/posix_acl.rb
+++ b/lib/puppet/type/posix_acl.rb
@@ -165,7 +165,7 @@ Puppet::Type.newtype(:posix_acl) do
     # Make sure we are not misinterpreting recursive permission notation (e.g. rwX) when
     # comparing current to new perms.
     def set_insync(cur_perm) # rubocop:disable Style/AccessorMethodName
-      should = @should.uniq.map(&:downcase).sort
+      should = @should.map(&:downcase).uniq.sort
       (cur_perm.sort == should) || (provider.check_set && (should - cur_perm).empty?)
     end
 


### PR DESCRIPTION
#### Pull Request (PR) description
This pull request includes a fix that @pyslarvt made to add rwX style settings that didn't appear to make it into a formal PR.  The fix as-is would frequently leave my hosts updating on every Puppet run.  The modifications I made add in support for properly comparison the current permissions set, even if you have the capital X bit set.  (note: X is only for setfacl, it's not a "real" posix acl, so you have to lowercase it to do comparisons)  This was already handled in the :unset handler, but not in set or exact.  Note it is possible that I've missed a few use cases as I don't really use anything but the set action.

I may follow this PR by writing up a quick README as well, depends on what time I have to spare.  =)

#### This Pull Request (PR) fixes the following issues
Fixes #9
