### PR TITLE
fix comparing permissions when they have a mix of upper- and lower-ca…

### DIFF
--- a/lib/puppet/provider/posix_acl/posixacl.rb
+++ b/lib/puppet/provider/posix_acl/posixacl.rb
@@ -94,12 +94,14 @@ Puppet::Type.type(:posix_acl).provide(:posixacl, parent: Puppet::Provider) do
       new_perm = @resource.value(:permission)
       # For comparison purposes, we want to change X to x as it's only useful
       # for setfacl and isn't stored or noted by getfacl.
+      lc_cur_perm = cur_perm.map(&:downcase)
       lc_new_perm = new_perm.map(&:downcase)
       perm_to_set = new_perm - cur_perm
-      perm_to_set_check = lc_new_perm - cur_perm
+      perm_to_set_check = lc_new_perm - lc_cur_perm
       # Unset perms always should match against lowercased x.
-      perm_to_unset = cur_perm - lc_new_perm
-      return false if perm_to_set_check.empty? && perm_to_unset.empty?
+      perm_to_unset = cur_perm - new_perm
+      perm_to_unset_check = lc_cur_perm - lc_new_perm
+      return false if perm_to_set_check.empty? && perm_to_unset_check.empty?
       # Take supplied perms literally, unset any existing perms which
       # are absent from ACLs given
       if check_exact

--- a/lib/puppet/type/posix_acl.rb
+++ b/lib/puppet/type/posix_acl.rb
@@ -165,8 +165,9 @@ Puppet::Type.newtype(:posix_acl) do
     # Make sure we are not misinterpreting recursive permission notation (e.g. rwX) when
     # comparing current to new perms.
     def set_insync(cur_perm) # rubocop:disable Style/AccessorMethodName
+      lc_cur_perm = cur_perm.map(&:downcase).uniq.sort
       should = @should.map(&:downcase).uniq.sort
-      (cur_perm.sort == should) || (provider.check_set && (should - cur_perm).empty?)
+      (lc_cur_perm.sort == should) || (provider.check_set && (should - lc_cur_perm).empty?)
     end
 
     def purge_insync(cur_perm)


### PR DESCRIPTION
e.g. on Debian there is a user `Debian-exim` - with an upper-case `D`.

Since the `v1.0.0` release this has led _puppet-posix_acl_ think the _permission_ property is all the time out-of-sync, as the module was comparing e.g. `u:Debian-exim:r--` against `u:debian-exim:r--` at certain places.

This PR fixes it for me - but I'm not sure if I have covered all the edge-cases.