### PR TITLE
Implement handling of missing files

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
   * [Using action => exact](#using-action-=>-exact)
   * [Using action => unset](#using-action-=>-unset)
   * [Using action => purge](#using-action-=>-purge)
+  * [Using ignore_missing](#using-ignore_missing)
 7. [Limitations](#limitations)
 
 
@@ -24,6 +25,7 @@ This plugin module provides a way to set POSIX 1.e (and other standards) file AC
 * The `action` parameter can be one of `set`, `exact`, `unset` or `purge`. These are described in detail below.
 * The `provider` parameter allows a choice of filesystem ACL provider. Currently only POSIX 1.e is implemented.
 * The `recursive` parameter allows you to apply the ACLs to all files under the specified path.
+* The `ignore_missing` parameter allows you to set the behavior in case the specified path is not found.
 
 ```
 posix_acl { "/var/log/httpd":
@@ -203,6 +205,12 @@ user::rwx
 group::r-x
 other::r-x
 ```
+
+### Using ignore_missing
+The `ignore_missing` parameter allows to set the behavior in case the specified path does not exist. It can take these values:
+* `false` (default): If the path is missing, an Error is raised.
+* `notify`: If the path is missing, no action is taken, but a notice is shown in the agent output.
+* `quiet`: If the path is missing, the ACL is silently ignored.
 
 ## Limitations
 ### Conflicts with "file" resource type:

--- a/lib/puppet/provider/posix_acl/posixacl.rb
+++ b/lib/puppet/provider/posix_acl/posixacl.rb
@@ -56,7 +56,7 @@ Puppet::Type.type(:posix_acl).provide(:posixacl, parent: Puppet::Provider) do
   end
 
   def permission
-    return [] unless File.exist?(@resource.value(:path))
+    return ['DOES_NOT_EXIST'] unless File.exist?(@resource.value(:path))
 
     value = []
     # String#lines would be nice, but we need to support Ruby 1.8.5

--- a/spec/unit/puppet/type/acl_spec.rb
+++ b/spec/unit/puppet/type/acl_spec.rb
@@ -128,6 +128,24 @@ describe acl_type do
       expect(resource[:recursemode]).to eq(:lazy)
     end
 
+    it 'gets ignore_missing false by default' do
+      resource = acl_type.new name: '/tmp/foo', permission: ['o::rwx']
+      expect(resource[:name]).to eq('/tmp/foo')
+      expect(resource[:ignore_missing]).to eq(:false)
+    end
+
+    it 'accepts an ignore_missing "quiet"' do
+      resource = acl_type.new name: '/tmp/foo', permission: ['o::rwx'], ignore_missing: :quiet
+      expect(resource[:name]).to eq('/tmp/foo')
+      expect(resource[:ignore_missing]).to eq(:quiet)
+    end
+
+    it 'accepts an ignore_missing "notice"' do
+      resource = acl_type.new name: '/tmp/foo', permission: ['o::rwx'], ignore_missing: :notify
+      expect(resource[:name]).to eq('/tmp/foo')
+      expect(resource[:ignore_missing]).to eq(:notify)
+    end
+
     it 'fails with a wrong action' do
       expect do
         acl_type.new name: '/tmp/foo', permission: ['o::rwx'], action: :xset
@@ -149,6 +167,12 @@ describe acl_type do
     it 'fails with a wrong last argument' do
       expect do
         acl_type.new name: '/tmp/foo', permission: ['user::-_-']
+      end.to raise_error
+    end
+
+    it 'fails with a wrong ignore_missing' do
+      expect do
+        acl_type.new name: '/tmp/foo', permission: ['o::rwx'], ignore_missing: :true
       end.to raise_error
     end
   end


### PR DESCRIPTION
#### Pull Request (PR) description
This pull requests add a paramter (`ignore_missing`) that allows controlling the behavior, if a path is not found on the target system. Currently, the modules fails at this point, as setfacl/getfacl fails.
With the new parameter, this can be configured to fail with error (as now; default), issue a notice in the agent's output or silently ignore the error.

#### Use case example
In our use case, we want to allow a monitoring user to read git repos in order to determine if they are at a specific commit. To allow this, we add `u:monitoring:rx` to the repo, via a hiera hash evaluated in a module present for each node. On some systems, this path may be missing (and is not monitored). We would like to be able to ignore this, as the repo also will not be checked.
We do not implenent the ACL in the monitoring module, as there may be requirements to add further ACLs to the same path.