### PR TITLE
Enable puppet lint for tests/docs

### DIFF
--- a/.puppet-lint.rc
+++ b/.puppet-lint.rc
@@ -1,3 +1,1 @@
 --fail-on-warnings
---no-parameter_documentation-check
---no-parameter_types-check

--- a/.sync.yml
+++ b/.sync.yml
@@ -1,1 +1,5 @@
 ---
+.puppet-lint.rc:
+  enabled_lint_checks:
+    - parameter_documentation
+    - parameter_types


### PR DESCRIPTION
This enables our puppet-lint plugins to enforce puppet-strings
documentation and datatypes for all parameters. Currently this module
has no parameters, but maybe someone in the future will add some.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
