### PR TITLE
Add acceptance test and documentation for file autorequire

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,17 @@
 
 
 ## Description
-This plugin module provides a way to set POSIX 1.e (and other standards) file ACLs via Puppet.
+This plugin module provides a way to set POSIX 1.e (and other standards) file
+ACLs via Puppet. It provides one class, `posix_acl::requirements`, which
+installs the acl package. It provides `setfacl` and `getfacl`. Those binaries
+are used by the Puppet Provider. You don't have to use the class, but the
+binaries need to be present. Puppet will autorequire the package. That means
+that all posix_acl resources will be applied after the acl package is
+installed, if the package resource is in the catalog.
+
+The type also has logic to autorequire filepaths. It will check the catalog for
+the path where you want to set ACLs and any paths above. If recursive is set to
+true, also ascendings paths are autorequired.
 
 ## Setup
 

--- a/spec/acceptance/basic_posix_acl_spec.rb
+++ b/spec/acceptance/basic_posix_acl_spec.rb
@@ -11,13 +11,7 @@ describe 'posix_acl' do
         user { 'blub':
           ensure => 'present',
         }
-        file { '/opt/test':
-          ensure => directory,
-          owner  => root,
-          group  => root,
-          mode   => '2770',
-        }
-        -> posix_acl { '/opt/test':
+        posix_acl { '/opt/test':
           action     => exact,
           permission => [
             'user::rwx',
@@ -29,6 +23,13 @@ describe 'posix_acl' do
           provider   => posixacl,
           recursive  => false,
           require => User['blub'],
+        }
+        # we declare the file resource after posix_acl to verfiy autorequire works
+        file { '/opt/test':
+          ensure => directory,
+          owner  => root,
+          group  => root,
+          mode   => '2770',
         }
         PUPPET
       end
@@ -43,13 +44,7 @@ describe 'posix_acl' do
         user { 'blub2':
           ensure => 'present',
         }
-        file { '/opt/test2':
-          ensure => directory,
-          owner  => root,
-          group  => root,
-          mode   => '2770',
-        }
-        -> posix_acl { '/opt/test2':
+        posix_acl { '/opt/test2':
           action     => exact,
           permission => [
             'user::rwx',
@@ -66,6 +61,13 @@ describe 'posix_acl' do
           provider   => posixacl,
           recursive  => false,
           require    => User['blub2'],
+        }
+        # we declare the file resource after posix_acl to verfiy autorequire works
+        file { '/opt/test2':
+          ensure => directory,
+          owner  => root,
+          group  => root,
+          mode   => '2770',
         }
         PUPPET2
       end

--- a/spec/acceptance/purge_posix_acl_spec.rb
+++ b/spec/acceptance/purge_posix_acl_spec.rb
@@ -11,13 +11,7 @@ describe 'posix_acl purging ACLs' do
         user { 'blub':
           ensure => 'present',
         }
-        file { '/opt/test':
-          ensure => directory,
-          owner  => root,
-          group  => root,
-          mode   => '2770',
-        }
-        -> posix_acl { '/opt/test':
+        posix_acl { '/opt/test':
           action     => exact,
           permission => [
             'user::rwx',
@@ -30,6 +24,13 @@ describe 'posix_acl purging ACLs' do
           recursive  => false,
           require => User['blub'],
         }
+        # we declare the file resource after posix_acl to verfiy autorequire works
+        file { '/opt/test':
+          ensure => directory,
+          owner  => root,
+          group  => root,
+          mode   => '2770',
+        }
         PUPPET
       end
     end
@@ -40,13 +41,7 @@ describe 'posix_acl purging ACLs' do
       let(:manifest) do
         <<-PUPPET2
         include posix_acl::requirements
-        file { '/opt/test5':
-          ensure => directory,
-          owner  => root,
-          group  => root,
-          mode   => '2770',
-        }
-        -> posix_acl { '/opt/test5':
+        posix_acl { '/opt/test5':
           action     => exact,
           permission => [
             'user::rwx',
@@ -60,6 +55,13 @@ describe 'posix_acl purging ACLs' do
           ],
           provider   => posixacl,
           recursive  => false,
+        }
+        # we declare the file resource after posix_acl to verfiy autorequire works
+        file { '/opt/test5':
+          ensure => directory,
+          owner  => root,
+          group  => root,
+          mode   => '2770',
         }
         PUPPET2
       end

--- a/spec/acceptance/updating_posix_acl_spec.rb
+++ b/spec/acceptance/updating_posix_acl_spec.rb
@@ -11,13 +11,7 @@ describe 'updating posix_acls' do
         user { ['blub', 'blub2']:
           ensure => 'present',
         }
-        file { '/opt/test3':
-          ensure => directory,
-          owner  => root,
-          group  => root,
-          mode   => '2770',
-        }
-        -> posix_acl { '/opt/test3':
+        posix_acl { '/opt/test3':
           action     => exact,
           permission => [
             'user::rwx',
@@ -29,6 +23,13 @@ describe 'updating posix_acls' do
           provider   => posixacl,
           recursive  => false,
           require => User['blub'],
+        }
+        # we declare the file resource after posix_acl to verfiy autorequire work
+        file { '/opt/test3':
+          ensure => directory,
+          owner  => root,
+          group  => root,
+          mode   => '2770',
         }
         PUPPET
       end
@@ -43,13 +44,7 @@ describe 'updating posix_acls' do
         user { ['blub', 'blub2']:
           ensure => 'present',
         }
-        file { '/opt/test3':
-          ensure => directory,
-          owner  => root,
-          group  => root,
-          mode   => '2770',
-        }
-        -> posix_acl { '/opt/test3':
+        posix_acl { '/opt/test3':
           action     => set,
           permission => [
             'user::rwx',
@@ -61,6 +56,13 @@ describe 'updating posix_acls' do
           provider   => posixacl,
           recursive  => false,
           require => User['blub2'],
+        }
+        # we declare the file resource after posix_acl to verfiy autorequire works
+        file { '/opt/test3':
+          ensure => directory,
+          owner  => root,
+          group  => root,
+          mode   => '2770',
         }
         PUPPET
       end
@@ -75,13 +77,7 @@ describe 'updating posix_acls' do
         user { ['blub', 'blub2']:
           ensure => 'present',
         }
-        file { '/opt/test3':
-          ensure => directory,
-          owner  => root,
-          group  => root,
-          mode   => '2770',
-        }
-        -> posix_acl { '/opt/test3':
+        posix_acl { '/opt/test3':
           action     => exact,
           permission => [
             'user::rwx',
@@ -93,6 +89,13 @@ describe 'updating posix_acls' do
           provider   => posixacl,
           recursive  => false,
           require => User['blub2'],
+        }
+        # we declare the file resource after posix_acl to verfiy autorequire works
+        file { '/opt/test3':
+          ensure => directory,
+          owner  => root,
+          group  => root,
+          mode   => '2770',
         }
         PUPPET
       end


### PR DESCRIPTION
In https://github.com/voxpupuli/puppet-posix_acl/pull/106 I wanted to
implement an autorequire for file resources. I noticed that the type
already has code to autorequire stuff:
https://github.com/voxpupuli/puppet-posix_acl/blob/3f267b290d7e3e1b4f64a2093f63ec9ac890766e/lib/puppet/type/posix_acl.rb#L95-L103

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
